### PR TITLE
fix cookies for local environment

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -29,6 +29,7 @@ const defaults = {
     host: process.env.REDIS_HOST || '127.0.0.1'
   },
   session: {
+    name: 'hof.sid',
     ttl: process.env.SESSION_TTL || 1800,
     secret: process.env.SESSION_SECRET || 'changethis'
   },

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -44,18 +44,17 @@ module.exports = (app, config) => {
   app.use(cookieParser(config.session.secret, {
     path: '/',
     httpOnly: true,
-    secure: true
+    secure: config.protocol === 'https'
   }));
 
-  const sessionOpts = Object.assign({}, {
+  const sessionOpts = Object.assign({
     store,
-    cookie: {secure: true},
-    key: '',
-    secret: '',
+    name: config.session.name,
+    cookie: {secure: config.protocol === 'https'},
+    secret: config.session.secret,
     saveUninitialized: true,
     resave: true,
-  },
-  config.session);
+  }, config.session);
 
   app.use(session(sessionOpts));
 


### PR DESCRIPTION
At the moment no session cookie is dropped when the app is started locally (`http://localhost:8080`).