### PR TITLE
Errorhandler i18n translate function resolves #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ You can call the `bootstrap` function with a list of [routes](#routes) and your 
 const bootstrap = require('hof-bootstrap');
 
 bootstrap({
-  views: ...,
-  errorHandler: ...,
+  views: 'optional_path_to_your_views',
   ...,
   routes: [{ ... }, { ... }]
 });
@@ -38,7 +37,6 @@ bootstrap({ ... }).then(bootstrapInterface => {
 - `start`: Start the server listening when the bootstrap function is called. Defaults to `true`.
 - `getCookies`: Load 'cookies' view at `GET /cookies`.
 - `getTerms`: Load 'terms' view at `GET /terms-and-conditions`.
-- `errorHandler`: Error handling middleware. Defaults to `hof.middleware.errors`.
 
 
 ## Routes

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -16,10 +16,6 @@ const defaults = {
   getTerms: true,
   viewEngine: 'html',
   baseController: hof.controllers.base,
-  errorHandler: require('hof').middleware.errors({
-    translate: require('hof').i18n.translate,
-    debug: process.env.NODE_ENV === 'development'
-  }),
   protocol: process.env.PROTOCOL || 'http',
   host: process.env.HOST || '0.0.0.0',
   port: process.env.PORT || '8080',


### PR DESCRIPTION
- invoke i18n function with a path to configure translations
- pass i18n translate function to error handler middleware in app
- remove error handler function from user options (./lib/defaults.js)
- update README
- fixed details with logger that was breaking the tests