### PR TITLE
Use hof-template-partials for common views

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,9 @@ cache:
   directories:
     - node_modules
 
+before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+  - npm cache clean
+
 script:
   - npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ node_js:
   - "6"
   - "4"
 
-cache:
-  directories:
-    - node_modules
-
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm cache clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,11 @@
 language: node_js
 node_js:
   - "6"
-  - "5"
   - "4"
-
-services:
-  - redis-server
 
 cache:
   directories:
     - node_modules
 
-before_install:
-  - rvm install 2.2.2
-
-before_script:
-  - npm run sass
-  - NODE_ENV='ci' npm start&
-
 script:
-  - npm run test:ci
-  - npm run test:acceptance
+  - npm run ci

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,6 +3,7 @@
 const hof = require('hof');
 const path = require('path');
 
+/* eslint no-process-env: "off" */
 const caller = process.env.NODE_ENV === 'test' ? 'test/' : path.dirname(module.parent.parent.filename);
 
 const defaults = {

--- a/lib/encryption.js
+++ b/lib/encryption.js
@@ -6,15 +6,15 @@ const algorithm = 'aes-256-ctr';
 module.exports = (password) => ({
 
   encrypt: (text) => {
-    const cipher = crypto.createCipher(algorithm,password)
-    let crypted = cipher.update(text,'utf8','hex')
+    const cipher = crypto.createCipher(algorithm, password);
+    let crypted = cipher.update(text, 'utf8', 'hex');
     crypted += cipher.final('hex');
     return crypted;
   },
 
   decrypt: (text) => {
-    const decipher = crypto.createDecipher(algorithm,password)
-    let dec = decipher.update(text,'hex','utf8')
+    const decipher = crypto.createDecipher(algorithm, password);
+    let dec = decipher.update(text, 'hex', 'utf8');
     dec += decipher.final('utf8');
     return dec;
   }

--- a/lib/router.js
+++ b/lib/router.js
@@ -8,16 +8,19 @@ const router = require('express').Router();
 const path = require('path');
 const fs = require('fs');
 
+const getPaths = (appPath, config) => ({
+  fields: config.fields ? path.resolve(config.caller, config.fields) : config.fields,
+  routeFields: path.resolve(config.caller, config.route.fields || `${appPath}/fields`),
+  templates: path.resolve(config.caller, config.route.views || `${appPath}/views`),
+  translations: path.resolve(config.caller, config.route.translations || `${appPath}/translations`)
+});
+
 module.exports = (config) => {
 
   const baseUrl = config.route.baseUrl || '/';
   const name = config.route.name || baseUrl.replace('/', '');
   const appPath = name ? `apps/${name}` : '.';
-  const paths = {
-    fields: config.fields ? path.resolve(config.caller, config.fields) : config.fields,
-    routeFields: path.resolve(config.caller, config.route.fields || `${appPath}/fields`),
-    templates: path.resolve(config.caller, config.route.views || `${appPath}/views`)
-  };
+  const paths = getPaths(appPath, config);
 
   let fields = {};
   let routeFields = {};
@@ -45,7 +48,7 @@ module.exports = (config) => {
   }
 
   const i18n = i18nFuture({
-    path: path.resolve(config.caller, config.route.translations || `${appPath}/translations`) + '/__lng__/__ns__.json'
+    path: paths.translations + '/__lng__/__ns__.json'
   });
 
   router.use(mixins(fields, {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -25,20 +25,22 @@ module.exports = (app, config) => {
 
   templates.setup(app);
 
+  let viewPaths = [require('hof-template-partials').views];
   app.set('view engine', viewEngine);
-
   app.enable('view cache');
 
   if (config.views) {
-    const viewsPath = path.resolve(config.caller, config.views);
+    const customViewPath = path.resolve(config.caller, config.views);
     try {
-      fs.accessSync(viewsPath, fs.F_OK);
+      fs.accessSync(customViewPath, fs.F_OK);
     } catch (err) {
-      throw new Error(`Cannot find views at ${viewsPath}`);
+      throw new Error(`Cannot find views at ${customViewPath}`);
     }
-    app.set('views',  viewsPath);
-    app.use(expressPartialTemplates(app));
+    viewPaths.unshift(customViewPath)
   };
+
+  app.set('views', viewPaths);
+  app.use(expressPartialTemplates(app));
 
   app.engine(viewEngine, hoganExpressStrict);
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -36,8 +36,8 @@ module.exports = (app, config) => {
     } catch (err) {
       throw new Error(`Cannot find views at ${customViewPath}`);
     }
-    viewPaths.unshift(customViewPath)
-  };
+    viewPaths.unshift(customViewPath);
+  }
 
   app.set('views', viewPaths);
   app.use(expressPartialTemplates(app));

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "connect-redis-crypto": "^2.1.0",
     "cookie-parser": "^1.4.1",
     "express": "^4.13.4",
-    "express-partial-templates": "^0.1.0",
+    "express-partial-templates": "^0.2.0",
     "express-session": "^1.13.0",
     "hof": "https://github.com/UKHomeOffice/hof.git#so-master",
+    "hof-template-partials": "^1.0.1",
     "hogan-express-strict": "^0.5.4",
     "redis": "^2.6.0-2",
     "winston": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "debug": "^2.2.0",
-    "eslint": "^0.23.0",
-    "eslint-config-homeoffice": "^0.1.4",
-    "hof-dotfiles": "^2.0.0",
     "istanbul": "^0.4.3",
     "jscs": "^3.0.3",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.13.4",
     "express-partial-templates": "^0.2.0",
     "express-session": "^1.13.0",
-    "hof": "https://github.com/UKHomeOffice/hof.git#so-master",
+    "hof": "UKHomeOffice/hof#so-master",
     "hof-template-partials": "^1.0.1",
     "hogan-express-strict": "^0.5.4",
     "redis": "^2.6.0-2",

--- a/test/fields/index.js
+++ b/test/fields/index.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = {}
+module.exports = {};

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -7,8 +7,6 @@ const path = require('path');
 
 describe('bootstrap()', () => {
 
-  let promise;
-
   it('must be given a list of routes', () =>
     (() => bootstrap()).should.Throw('Must be called with a list of routes')
   );
@@ -63,7 +61,7 @@ describe('bootstrap()', () => {
         fields: 'fields'
       }]
     }).then(api => {
-      api.server.should.be.an.instanceof(http.Server)
+      api.server.should.be.an.instanceof(http.Server);
       api.stop();
     })
   );
@@ -75,7 +73,7 @@ describe('bootstrap()', () => {
         steps: {}
       }]
     }).then(api => {
-      api.server.should.be.an.instanceof(http.Server)
+      api.server.should.be.an.instanceof(http.Server);
       api.stop();
     })
   );
@@ -113,7 +111,6 @@ describe('bootstrap()', () => {
     it('serves the correct view when requested from each step', () =>
       bootstrap({
         routes: [{
-          // baseUrl: '/path',
           steps: {
             '/one': {},
             '/two': {}
@@ -123,13 +120,13 @@ describe('bootstrap()', () => {
         request(api.server)
           .get('/one')
           .expect(200)
-          .expect(res => res.text.should.eql('<div>one</div>\n'))
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
         return api;
       }).then(api => {
         request(api.server)
           .get('/two')
           .expect(200)
-          .expect(res => res.text.should.eql('<div>one</div>\n'))
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
         return api;
       }).then(api => api.stop())
     );
@@ -146,7 +143,7 @@ describe('bootstrap()', () => {
         request(api.server)
           .get('/baseUrl/one')
           .expect(200)
-          .expect(res => res.text.should.eql('<div>one</div>\n'))
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
         return api;
       }).then(api => api.stop())
     );
@@ -163,7 +160,7 @@ describe('bootstrap()', () => {
         request(api.server)
           .get('/one/param')
           .expect(200)
-          .expect(res => res.text.should.eql('<div>one</div>\n'))
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
         return api;
       }).then(api => api.stop())
     );
@@ -180,7 +177,7 @@ describe('bootstrap()', () => {
         request(api.server)
           .get('/one')
           .expect(200)
-          .expect(res => res.text.should.eql('<div>one</div>\n'))
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
         return api;
       }).then(api => api.stop())
     );
@@ -210,7 +207,7 @@ describe('bootstrap()', () => {
         request(api.server)
           .get('/one')
           .expect(200)
-          .expect(res => res.text.should.eql('<div>one</div>\n'))
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
         return api;
       }).then(api => api.stop())
     );


### PR DESCRIPTION
resolves https://github.com/UKHomeOffice/hof-bootstrap/issues/16

- install hof-template-partials
- update express-partial-templates

hof-template-partials exports views and translations
This update means we can remove the commonly used views from the service that consumes bootstrap and import the views from hof-template-partials