### PR TITLE
resolves #17 - remove redis crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "body-parser": "^1.15.1",
     "churchill": "0.0.5",
     "connect-redis": "^3.1.0",
-    "connect-redis-crypto": "^2.1.0",
     "cookie-parser": "^1.4.1",
     "express": "^4.13.4",
     "express-partial-templates": "^0.2.0",


### PR DESCRIPTION
We don't use this anymore. It's replaced with out own simple encryption/decryption methods