### PR TITLE
Make async tests run and not fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - "6"
   - "4"
 
+services:
+  - redis-server
+
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm cache clean

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const app = require('express')();
 const churchill = require('churchill');
 const path = require('path');
+const hofMiddleware = require('hof').middleware;
 const router = require('./lib/router');
 const serveStatic = require('./lib/serve-static');
 const sessionStore = require('./lib/sessions');
@@ -79,6 +80,9 @@ module.exports = options => {
   settings(app, config);
   sessionStore(app, config);
 
+  // check for cookies
+  app.use(hofMiddleware.cookies());
+
   load(config);
 
   return new Promise((resolve) => {
@@ -89,7 +93,7 @@ module.exports = options => {
       if (config.getTerms === true) {
         app.get('/terms-and-conditions', (req, res) => res.render('terms', i18n.translate('terms')));
       }
-      bootstrap.use(require('hof').middleware.errors({
+      bootstrap.use(hofMiddleware.errors({
         translate: i18n.translate.bind(i18n),
         debug: config.env === 'development'
       }));

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "istanbul": "^0.4.3",
     "jscs": "^3.0.3",
     "mocha": "^2.4.5",
-    "supertest": "^1.2.0"
+    "supertest": "^1.2.0",
+    "supertest-as-promised": "^3.2.0"
   }
 }


### PR DESCRIPTION
- return test assertion to promise thenable (like calling done)
- set a cookie for each test that makes a get request so as not to fail with a 302
- add cookie middleware to help identify cookie failures (302's)
- add custom route view path to bootstrap functions to override hof-template-partials.views