### PR TITLE
Remove the `assetPath` option

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
+test/public
 coverage
 LICENSE
 README.md

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,5 @@
 {
   "preset": "google",
   "maximumLineLength": 120,
-  "excludeFiles": ["node_modules/**", "coverage/**"]
+  "excludeFiles": ["node_modules/**", "coverage/**", "test/public/**"]
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ If the service consists of multiple form journeys
 
 ## Options
 
-- `assetPath`: Location of the static assets relative to the root of your project. Defaults to 'public'.
 - `views`: Location of the base views relative to the root of your project. Defaults to 'views'.
 - `fields`: Location of the common fields relative to the root of your project. Defaults to 'fields'.
 - `translations`: Location of the common translations relative to the root of your project. Defaults to 'translations'.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -9,7 +9,6 @@ const realPath = path.dirname(module.parent.parent.filename);
 const caller = process.env.NODE_ENV === 'test' ? testPath : realPath;
 
 const defaults = {
-  assetPath: 'public',
   translations: 'translations',
   views: 'views',
   fields: 'fields',

--- a/lib/serve-static.js
+++ b/lib/serve-static.js
@@ -6,7 +6,7 @@ const path = require('path');
 module.exports = (app, config) => {
 
   if (config.env === 'development' || config.env === 'docker' || config.env === 'test') {
-    app.use('/public', express.static(path.resolve(config.caller, config.assetPath)));
+    app.use('/public', express.static(path.resolve(config.caller, 'public')));
   }
 
   return app;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -205,9 +205,8 @@ describe('bootstrap()', () => {
       )
     );
 
-    it('serves from optional assetPath on request to public', () =>
+    it('serves static resources from /public', () =>
       bootstrap({
-        assetPath: 'asset-test',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -221,9 +220,8 @@ describe('bootstrap()', () => {
       )
     );
 
-    it('returns a 404 if the asset does not exist', () =>
+    it('returns a 404 if the resource does not exist', () =>
       bootstrap({
-        assetPath: 'asset-test',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {

--- a/test/public/test.js
+++ b/test/public/test.js
@@ -1,0 +1,1 @@
+function test() {};


### PR DESCRIPTION
- remove `assetPath` option because there is no way to pass this js option into nginx proxy config
- hard-code mount fs location for express.static to 'public'
- update test and fixture to ensure static is served from `/public`