### PR TITLE
Allow sessionStore to be passed in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+coverage
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If the service consists of multiple form journeys
 - `start`: Start the server listening when the bootstrap function is called. Defaults to `true`.
 - `getCookies`: Load 'cookies' view at `GET /cookies`.
 - `getTerms`: Load 'terms' view at `GET /terms-and-conditions`.
+- `sessionStore`: Provide a sessionStore to be used in place of redis. Suggest using [https://github.com/expressjs/session/blob/master/session/memory.js](express-session.MemoryStore) for development and acceptance testing.
 
 
 ## Routes

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ module.exports = options => {
     },
 
     start: config => {
+      // eslint-disable-next-line consistent-return
       return new Promise((resolve, reject) => {
         if (config.start !== false) {
           if (!config.protocol) {
@@ -39,13 +40,14 @@ module.exports = options => {
           bootstrap.server = require(config.protocol).createServer(app);
           try {
             bootstrap.server.listen(config.port, config.host, () => {
-              resolve(bootstrap);
+              return resolve(bootstrap);
             });
           } catch (err) {
-            reject(err);
+            return reject(err);
           }
+        } else {
+          return resolve(bootstrap);
         }
-        return resolve(bootstrap);
       });
     },
 

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -9,6 +9,21 @@ module.exports = (app, config) => {
 
   const logger = config.logger || console;
 
+  app.use(cookieParser(config.session.secret, {
+    path: '/',
+    httpOnly: true,
+    secure: config.protocol === 'https'
+  }));
+
+  if (config.sessionStore) {
+    return app.use(session({
+      store: config.sessionStore,
+      genid: () => 'fakeId',
+      saveUninitialized: true,
+      resave: false,
+    }));
+  }
+
   const encryption = require('./encryption')(config.session.secret);
   const RedisStore = connectRedis(session);
   const client = redis.createClient(config.redis.port, config.redis.host);
@@ -43,12 +58,6 @@ module.exports = (app, config) => {
 
   app.set('trust proxy', 1);
 
-  app.use(cookieParser(config.session.secret, {
-    path: '/',
-    httpOnly: true,
-    secure: config.protocol === 'https'
-  }));
-
   const sessionOpts = Object.assign({
     store,
     name: config.session.name,
@@ -60,4 +69,5 @@ module.exports = (app, config) => {
 
   app.use(session(sessionOpts));
 
+  return client;
 };

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -54,29 +54,37 @@ describe('bootstrap()', () => {
     })).should.Throw('Cannot find route views at ' + path.resolve(__dirname, '../../test/not_a_valid_path'))
   );
 
-  it('uses the route fields as the path', () =>
+  it('uses the route fields as the path', done =>
     bootstrap({
       routes: [{
         views: path.resolve(__dirname, '../apps/app_1/views'),
         steps: {},
         fields: 'fields'
       }]
-    }).then(api => api.server.should.be.an.instanceof(http.Server))
+    }).then(api => {
+      api.server.should.be.an.instanceof(http.Server);
+      api.stop();
+      done();
+    })
   );
 
-  it('uses the name to find a path to the fields', () =>
+  it('uses the name to find a path to the fields', done =>
     bootstrap({
       routes: [{
         views: path.resolve(__dirname, '../apps/app_1/views'),
         name: 'app_1',
         steps: {}
       }]
-    }).then(api => api.server.should.be.an.instanceof(http.Server))
+    }).then(api => {
+      api.server.should.be.an.instanceof(http.Server);
+      api.stop();
+      done();
+    })
   );
 
   describe('with valid routes and steps', () => {
 
-    it('returns a promise that resolves with the bootstrap interface', () =>
+    it('returns a promise that resolves with the bootstrap interface', done =>
       bootstrap({
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -84,10 +92,14 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => api.should.have.keys('server', 'stop', 'start', 'use'))
+      }).then(api => {
+        api.should.have.keys('server', 'stop', 'start', 'use');
+        api.stop();
+        done();
+      })
     );
 
-    it('starts the service and responds successfully', () =>
+    it('starts the service and responds successfully', done =>
       bootstrap({
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -95,14 +107,17 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => request(api.server)
-        .get('/one')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(200)
-      )
+      }).then(api => {
+        request(api.server)
+          .get('/one')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200);
+        api.stop();
+        done();
+      })
     );
 
-    it('serves the correct view when requested from each step', () =>
+    it('serves the correct view when requested from each step', done =>
       bootstrap({
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -111,22 +126,24 @@ describe('bootstrap()', () => {
             '/two': {}
           }
         }]
-      }).then(api =>
-        request(api.server)
+      }).then(api => request(api.server)
           .get('/one')
           .set('Cookie', ['myCookie=1234'])
           .expect(200)
           .expect(res => res.text.should.eql('<div>one</div>\n')
-        ).then(() => request(api.server)
-          .get('/two')
-          .set('Cookie', ['myCookie=1234'])
-          .expect(200)
-          .expect(res => res.text.should.eql('<div>two</div>\n'))
-        )
+        ).then(() => {
+          request(api.server)
+            .get('/two')
+            .set('Cookie', ['myCookie=1234'])
+            .expect(200)
+            .expect(res => res.text.should.eql('<div>two</div>\n'));
+          api.stop();
+          done();
+        })
       )
     );
 
-    it('uses a route baseUrl to serve the views and fields at the correct step', () =>
+    it('uses a route baseUrl to serve the views and fields at the correct step', done =>
       bootstrap({
         routes: [{
           baseUrl: '/app_1',
@@ -134,15 +151,18 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => request(api.server)
-        .get('/app_1/one')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(200)
-        .expect(res => res.text.should.eql('<div>one</div>\n'))
-      )
+      }).then(api => {
+        request(api.server)
+          .get('/app_1/one')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200)
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
+        api.stop();
+        done();
+      })
     );
 
-    it('can be given a route param', () =>
+    it('can be given a route param', done =>
       bootstrap({
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -151,15 +171,18 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => request(api.server)
-        .get('/one/param')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(200)
-        .expect(res => res.text.should.eql('<div>one</div>\n'))
-      )
+      }).then(api => {
+        request(api.server)
+          .get('/one/param')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200)
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
+        api.stop();
+        done();
+      })
     );
 
-    it('accepts a baseController option', () =>
+    it('accepts a baseController option', done =>
       bootstrap({
         baseController: require('hof').controllers.base,
         routes: [{
@@ -168,15 +191,18 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => request(api.server)
-        .get('/one')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(200)
-        .expect(res => res.text.should.eql('<div>one</div>\n'))
-      )
+      }).then(api => {
+        request(api.server)
+          .get('/one')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200)
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
+        api.stop();
+        done();
+      })
     );
 
-    it('does not start the service if start is false', () =>
+    it('does not start the service if start is false', done =>
       bootstrap({
         start: false,
         routes: [{
@@ -184,10 +210,13 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => should.equal(api.server, undefined))
+      }).then(api => {
+        should.equal(api.server, undefined);
+        done();
+      })
     );
 
-    it('starts the server when start is called', () =>
+    it('starts the server when start is called', done =>
       bootstrap({
         start: false,
         routes: [{
@@ -197,15 +226,18 @@ describe('bootstrap()', () => {
         }]
       })
       .then(api => api.start({start: true}))
-      .then(api => request(api.server)
-        .get('/one')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(200)
-        .expect(res => res.text.should.eql('<div>one</div>\n'))
-      )
+      .then(api => {
+        request(api.server)
+          .get('/one')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200)
+          .expect(res => res.text.should.eql('<div>one</div>\n'));
+        api.stop();
+        done();
+      })
     );
 
-    it('serves static resources from /public', () =>
+    it('serves static resources from /public', done =>
       bootstrap({
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -213,14 +245,17 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => request(api.server)
-        .get('/public/test.js')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(200)
-      )
+      }).then(api => {
+        request(api.server)
+          .get('/public/test.js')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(200);
+        api.stop();
+        done();
+      })
     );
 
-    it('returns a 404 if the resource does not exist', () =>
+    it('returns a 404 if the resource does not exist', done =>
       bootstrap({
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -228,11 +263,14 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).then(api => request(api.server)
-        .get('/public/not-here.js')
-        .set('Cookie', ['myCookie=1234'])
-        .expect(404)
-      )
+      }).then(api => {
+        request(api.server)
+          .get('/public/not-here.js')
+          .set('Cookie', ['myCookie=1234'])
+          .expect(404);
+        api.stop();
+        done();
+      })
     );
 
   });


### PR DESCRIPTION
* added .gitignore
* only resolve promise if start === false - we were instantly resolving before.
* fix async issues in tests due to the above change
* apply session middleware with sessionStore and barebones config if ci and sessionStore supplied.