### PR TITLE
Pass name to wizard

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -62,6 +62,10 @@ module.exports = (config) => {
     templatePath: paths.templates
   };
 
+  if (name) {
+    wizardConfig.name = name;
+  }
+
   if (config.route.params) {
     wizardConfig.params = config.route.params;
   }


### PR DESCRIPTION
* As a router I should pass my name to the wizard if present.
* Wizard assigns a new session key in the format hmpo-wizard={name}
* If name is missing, it increments an integer