### PR TITLE
Return bootstrap interface object, not a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Uses the following settings;
  * `@param {Function}` middleware.
  * `@return {Object} bootstrap` interface object.
 
+The use function can only be used if bootstrap is called with `{ start: false }` passed in config, `bootstrap.start()` will need to be called afterwards to start the app. This is due to the significance of the order in which middleware are applied. Alternatively an array of middleware functions can be passed in config.
 
 ### `server`
 
@@ -86,6 +87,7 @@ If the service consists of multiple form journeys
 ## Options
 
 - `views`: Location of the base views relative to the root of your project. Defaults to 'views'.
+- `middleware`: An optional array of middleware functions to add to the application middleware pipeline.
 - `fields`: Location of the common fields relative to the root of your project. Defaults to 'fields'.
 - `translations`: Location of the common translations relative to the root of your project. Defaults to 'translations'.
 - `viewEngine`: Name of the express viewEngine. Defaults to 'html'.

--- a/README.md
+++ b/README.md
@@ -16,16 +16,42 @@ bootstrap({
 });
 ```
 
-**NOTE**: `bootstrap` returns a promise that resolves with with the bootstrap interface, which means you can call methods on bootstrap, such as;
-```
-bootstrap({ ... }).then(bootstrapInterface => {
-  if (conditionIsMet)
-    bootstrapInterface.stop();
-    bootstrapInterface.use(middleware);
-    bootstrapInterface.start();
-  }
-});
-```
+
+## Interface
+`bootstrap` returns the bootstrap interface object, which includes `start`, `use`, `stop`, and `server`.
+
+### `start` Function(options)
+
+ * Creates and starts the server listening for connections.
+ * `@param {Object}` options
+ * `@return {Object} bootstrap` interface object.
+
+Convenient if starting was deferred during the initial invocation of `hof-bootstrap` with the option and value `start: false` or the server has been stopped. Returns the `bootstrap` interface object.
+
+Uses the following settings;
+
+  - `port`: 8080 or `NODE_ENV.port`
+  - `host`: '0.0.0.0' or `NODE_ENV.host`
+  - `protocol`: 'http' or `NODE_ENV.protocol`
+
+
+### `stop` Function(callback)
+
+ * Closes the server, stops listening for connections
+ * `@param {Function}` callback. Useful for testing
+ * `@return {Object} bootstrap` interface object.
+
+### `use` Function(middleware)
+
+ * Alias for Express's `app.use`.`
+ * `@param {Function}` middleware.
+ * `@return {Object} bootstrap` interface object.
+
+
+### `server`
+
+ * Instance of an `http`/`https` server bound to the `app`
+ * `@type {Object}
 
 ## Structure
 `bootstrap` does not dictate how to structure your service, however, it does provide a number of default settings so you don't need to pass in anything other than a `route` and `steps`.

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = options => {
 
   const bootstrap = {
 
-    use: middleware => {
+    use() {
       app.use.apply(app, arguments);
       return bootstrap;
     },

--- a/index.js
+++ b/index.js
@@ -48,7 +48,9 @@ module.exports = options => {
 
   const bootstrap = {
 
-    server: null,
+    app: Object.assign(app, {
+      server: null
+    }),
 
     use: middleware => {
       app.use(middleware);
@@ -62,21 +64,21 @@ module.exports = options => {
 
       const protocol = config.protocol === 'http' ? http : https;
 
-      bootstrap.server = protocol.createServer(app);
+      app.server = protocol.createServer(app);
 
       applyErrorMiddlewares(config, i18n);
 
-      bootstrap.server.listen(config.port, config.host);
+      app.server.listen(config.port, config.host);
       return bootstrap;
     },
 
     stop: (callback) => {
       _.defer(() => {
-        bootstrap.server.close();
+        app.server.close();
       });
 
       if (callback) {
-        callback(bootstrap.server);
+        callback(app.server);
       }
       return bootstrap;
     }

--- a/lib/router.js
+++ b/lib/router.js
@@ -15,16 +15,9 @@ const getPaths = (appPath, config) => ({
   translations: path.resolve(config.caller, config.route.translations || `${appPath}/translations`)
 });
 
-// eslint-disable-next-line complexity
-module.exports = (config) => {
-
-  const baseUrl = config.route.baseUrl || '/';
-  const name = config.route.name || baseUrl.replace('/', '');
-  const appPath = name ? `apps/${name}` : '.';
-  const paths = getPaths(appPath, config);
-
-  let fields = {};
-  let routeFields = {};
+const getFields = paths => {
+  let routeFields;
+  let fields;
 
   try {
     if (paths.fields) {
@@ -33,14 +26,21 @@ module.exports = (config) => {
   } catch (err) {
     throw new Error(`Cannot find fields at ${paths.fields}`);
   }
-
   try {
     routeFields = require(paths.routeFields);
   } catch (err) {
     throw new Error(`Cannot find route fields at ${paths.routeFields}`);
   }
+  return Object.assign({}, fields, routeFields);
+};
 
-  fields = Object.assign({}, fields, routeFields);
+module.exports = (config) => {
+
+  const baseUrl = config.route.baseUrl || '/';
+  const name = config.route.name || baseUrl.replace('/', '');
+  const appPath = name ? `apps/${name}` : '.';
+  const paths = getPaths(appPath, config);
+  const fields = getFields(paths);
 
   try {
     fs.accessSync(paths.templates, fs.F_OK);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "istanbul": "^0.4.3",
     "jscs": "^3.0.3",
     "mocha": "^2.4.5",
+    "sinomocha": "^0.2.4",
+    "sinon": "^1.17.5",
+    "sinon-chai": "^2.8.0",
     "supertest": "^1.2.0",
     "supertest-as-promised": "^3.2.0"
   }

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,9 @@
 'use strict';
 
-global.should = require('chai').should();
+global.chai = require('chai').use(require('sinon-chai'));
+global.should = chai.should();
+global.sinon = require('sinon');
+require('sinomocha')();
 
 process.setMaxListeners(0);
 process.stdout.setMaxListeners(0);

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -83,7 +83,7 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).should.have.all.keys('server', 'stop', 'start', 'use')
+      }).should.have.all.keys('app', 'stop', 'start', 'use')
     );
 
     it('starts the service and responds successfully', () => {
@@ -95,7 +95,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200);
@@ -110,7 +110,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -127,7 +127,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/app_1/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -144,7 +144,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/one/param')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -161,7 +161,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -179,7 +179,7 @@ describe('bootstrap()', () => {
         }]
       });
 
-      return should.equal(bs.server, null);
+      return should.equal(bs.app.server, null);
     });
 
     it('starts the service when start is called', () => {
@@ -193,7 +193,7 @@ describe('bootstrap()', () => {
         }]
       }).start();
 
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -214,7 +214,7 @@ describe('bootstrap()', () => {
         host: '1.1.1.1'
       });
 
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -249,7 +249,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/public/test.js')
         .set('Cookie', ['myCookie=1234'])
         .expect(200);
@@ -264,7 +264,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.server)
+      return request(bs.app.server)
         .get('/public/not-here.js')
         .set('Cookie', ['myCookie=1234'])
         .expect(404);

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -172,6 +172,7 @@ describe('bootstrap()', () => {
       const bs = bootstrap({
         start: false,
         routes: [{
+          views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
             '/one': {}
           }
@@ -185,11 +186,33 @@ describe('bootstrap()', () => {
       const bs = bootstrap({
         start: false,
         routes: [{
+          views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
             '/one': {}
           }
         }]
       }).start();
+
+      return request(bs.server)
+        .get('/one')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(200)
+        .expect(res => res.text.should.eql('<div>one</div>\n'));
+    });
+
+    it('merges start options with the bootstrap config', () => {
+      const bs = bootstrap({
+        start: false,
+        routes: [{
+          views: path.resolve(__dirname, '../apps/app_1/views'),
+          steps: {
+            '/one': {}
+          }
+        }]
+      }).start({
+        port: '8001',
+        host: '1.1.1.1'
+      });
 
       return request(bs.server)
         .get('/one')
@@ -212,7 +235,7 @@ describe('bootstrap()', () => {
           .get('/one')
           .end(error => {
             error.should.be.instanceof(Error);
-            error.code.should.equal('ECONNRESET');
+            return error.code.should.equal('ECONNRESET');
           })
       )
     );

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -83,7 +83,7 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).should.have.all.keys('app', 'stop', 'start', 'use')
+      }).should.have.all.keys('server', 'stop', 'start', 'use')
     );
 
     it('starts the service and responds successfully', () => {
@@ -95,7 +95,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200);
@@ -110,7 +110,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -127,7 +127,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/app_1/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -144,7 +144,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/one/param')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -161,7 +161,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -179,7 +179,7 @@ describe('bootstrap()', () => {
         }]
       });
 
-      return should.equal(bs.app.server, null);
+      return should.equal(bs.server, null);
     });
 
     it('starts the service when start is called', () => {
@@ -193,7 +193,7 @@ describe('bootstrap()', () => {
         }]
       }).start();
 
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -214,7 +214,7 @@ describe('bootstrap()', () => {
         host: '1.1.1.1'
       });
 
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/one')
         .set('Cookie', ['myCookie=1234'])
         .expect(200)
@@ -249,7 +249,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/public/test.js')
         .set('Cookie', ['myCookie=1234'])
         .expect(200);
@@ -264,7 +264,7 @@ describe('bootstrap()', () => {
           }
         }]
       });
-      return request(bs.app.server)
+      return request(bs.server)
         .get('/public/not-here.js')
         .set('Cookie', ['myCookie=1234'])
         .expect(404);


### PR DESCRIPTION
### This will be a breaking change

- make interface chaninable by returning bootstrap from interface methods
- remove promise so no more `then`
- apply error middleware in the start method so middleware applied with `bootstrap.use` will be applied before error md.
- move some set up to functions outside of module definition
- update readme documentation
- also, fixed lint error in lib/router