### PR TITLE
Enhancement/no more global

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bootstrap({
 
  * Creates and starts the server listening for connections.
  * `@param {Object}` options
- * `@return {Promise.<bootstrap, Error>}` a promise that returns bootstrap interface object if resolved, Error if rejected.
+ * `@return {Promise.<bootstrap|Error>}` a promise that returns bootstrap interface object if resolved, Error if rejected.
 
 Convenient if starting was deferred during the initial invocation of `hof-bootstrap` with the option and value `start: false` or the server has been stopped. Returns a promise which resolves to the `bootstrap` interface object.
 
@@ -39,7 +39,7 @@ Uses the following settings;
 
  * Closes the server, stops listening for connections
  * `@param {Function}` callback. Useful for testing
- * `@return {Promise.<bootstrap, Error>}` a promise that returns bootstrap interface object if resolved, Error if rejected.
+ * `@return {Promise.<bootstrap|Error>}` a promise that returns bootstrap interface object if resolved, Error if rejected.
 
 ### `use` Function(middleware)
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ bootstrap({
 
  * Creates and starts the server listening for connections.
  * `@param {Object}` options
- * `@return {Object} bootstrap` interface object.
+ * `@return {Promise.<bootstrap, Error>}` a promise that returns bootstrap interface object if resolved, Error if rejected.
 
-Convenient if starting was deferred during the initial invocation of `hof-bootstrap` with the option and value `start: false` or the server has been stopped. Returns the `bootstrap` interface object.
+Convenient if starting was deferred during the initial invocation of `hof-bootstrap` with the option and value `start: false` or the server has been stopped. Returns a promise which resolves to the `bootstrap` interface object.
 
 Uses the following settings;
 
@@ -39,7 +39,7 @@ Uses the following settings;
 
  * Closes the server, stops listening for connections
  * `@param {Function}` callback. Useful for testing
- * `@return {Object} bootstrap` interface object.
+ * `@return {Promise.<bootstrap, Error>}` a promise that returns bootstrap interface object if resolved, Error if rejected.
 
 ### `use` Function(middleware)
 

--- a/index.js
+++ b/index.js
@@ -73,13 +73,23 @@ module.exports = options => {
       loadRoutes(app, config);
       applyErrorMiddlewares(app, config, i18n);
 
-      return new Promise(resolve => {
-        bootstrap.server.listen(config.port, config.host, () => resolve(bootstrap));
+      return new Promise((resolve, reject) => {
+        bootstrap.server.listen(config.port, config.host, err => {
+          if (err) {
+            reject(new Error('Unable to connect to server'));
+          }
+          resolve(bootstrap));
+        };
       });
     },
 
     stop() {
-      return new Promise(resolve => bootstrap.server.close(() => resolve(bootstrap)));
+      return new Promise((resolve, reject) => bootstrap.server.close(err => {
+        if (err) {
+          reject(new Error('Unable to stop server'));
+        }
+        resolve(bootstrap);
+      }));
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ module.exports = options => {
           if (err) {
             reject(new Error('Unable to connect to server'));
           }
-          resolve(bootstrap));
-        };
+          resolve(bootstrap)
+        });
       });
     },
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const app = require('express')();
+const express = require('express');
 const hof = require('hof');
 const churchill = require('churchill');
 const path = require('path');
 const http = require('http');
 const https = require('https');
-const _ = require('lodash');
 const router = require('./lib/router');
 const serveStatic = require('./lib/serve-static');
 const sessionStore = require('./lib/sessions');
@@ -19,14 +18,17 @@ const getConfig = function getConfig() {
   return Object.assign.apply(null, [{}, defaults].concat(args));
 };
 
-const loadRoutes = config => {
+const loadRoutes = (app, config) => {
   config.routes.forEach(route => {
-    const routeConfig = Object.assign({}, {route}, config);
-    app.use(router(routeConfig));
+    const routeConfig = Object.assign({}, config, {
+      route,
+      sharedViews: app.get('views')
+    });
+    app.use(route.baseUrl || '/', router(routeConfig));
   });
 };
 
-const applyErrorMiddlewares = (config, i18n) => {
+const applyErrorMiddlewares = (app, config, i18n) => {
   app.use(hof.middleware.notFound({
     logger: config.logger,
     translate: i18n.translate.bind(i18n),
@@ -39,6 +41,8 @@ const applyErrorMiddlewares = (config, i18n) => {
 };
 
 module.exports = options => {
+
+  const app = express();
 
   let config = getConfig(options);
 
@@ -66,24 +70,17 @@ module.exports = options => {
 
       app.use(hof.middleware.cookies());
 
-      loadRoutes(config);
-      applyErrorMiddlewares(config, i18n);
+      loadRoutes(app, config);
+      applyErrorMiddlewares(app, config, i18n);
 
-      bootstrap.server.listen(config.port, config.host);
-      return bootstrap;
+      return new Promise(resolve => {
+        bootstrap.server.listen(config.port, config.host, () => resolve(bootstrap));
+      });
     },
 
-    stop: (callback) => {
-      _.defer(() => {
-        bootstrap.server.close();
-      });
-
-      if (callback) {
-        callback(bootstrap.server);
-      }
-      return bootstrap;
+    stop() {
+      return new Promise(resolve => bootstrap.server.close(() => resolve(bootstrap)));
     }
-
   };
 
   i18n.on('ready', () => {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = options => {
           if (err) {
             reject(new Error('Unable to connect to server'));
           }
-          resolve(bootstrap)
+          resolve(bootstrap);
         });
       });
     },

--- a/lib/router.js
+++ b/lib/router.js
@@ -66,7 +66,7 @@ module.exports = (config) => {
   app.use(mixins(fields));
 
   const wizardConfig = {
-    controller: config.baseController || hof.controllers.base
+    controller: config.baseController
   };
 
   if (name) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const hof = require('hof');
+const expressPartialTemplates = require('express-partial-templates');
 const wizard = hof.wizard;
 const mixins = hof.mixins;
 const i18nFuture = hof.i18n;
-const router = require('express').Router();
+const express = require('express');
 const path = require('path');
 const fs = require('fs');
 
@@ -36,6 +37,8 @@ const getFields = paths => {
 
 module.exports = (config) => {
 
+  const app = express();
+
   const baseUrl = config.route.baseUrl || '/';
   const name = config.route.name || baseUrl.replace('/', '');
   const appPath = name ? `apps/${name}` : '.';
@@ -52,15 +55,18 @@ module.exports = (config) => {
     path: paths.translations + '/__lng__/__ns__.json'
   });
 
-  router.use(hof.middleware.deepTranslate({
+  app.set('views', [paths.templates].concat(config.sharedViews));
+
+  app.use(expressPartialTemplates(app));
+
+  app.use(hof.middleware.deepTranslate({
     translate: i18n.translate.bind(i18n)
   }));
 
-  router.use(mixins(fields));
+  app.use(mixins(fields));
 
   const wizardConfig = {
-    controller: config.baseController || hof.controllers.base,
-    templatePath: paths.templates
+    controller: config.baseController || hof.controllers.base
   };
 
   if (name) {
@@ -71,8 +77,8 @@ module.exports = (config) => {
     wizardConfig.params = config.route.params;
   }
 
-  router.use(baseUrl, wizard(config.route.steps, fields, wizardConfig));
+  app.use(wizard(config.route.steps, fields, wizardConfig));
 
-  return router;
+  return app;
 
 };

--- a/test/apps/app_2/views/common.html
+++ b/test/apps/app_2/views/common.html
@@ -1,0 +1,1 @@
+<div>from app 2</div>

--- a/test/apps/app_2/views/partials/app-2-partial.html
+++ b/test/apps/app_2/views/partials/app-2-partial.html
@@ -1,0 +1,1 @@
+<div>app 2 partial</div>

--- a/test/apps/common/views/common.html
+++ b/test/apps/common/views/common.html
@@ -1,0 +1,1 @@
+<div>from common</div>

--- a/test/apps/common/views/partials/common-partial.html
+++ b/test/apps/common/views/partials/common-partial.html
@@ -1,0 +1,1 @@
+<div>common partial</div>

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -191,7 +191,9 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).start();
+      });
+
+      bs.start();
 
       return request(bs.server)
         .get('/one')
@@ -209,7 +211,9 @@ describe('bootstrap()', () => {
             '/one': {}
           }
         }]
-      }).start({
+      });
+
+      bs.start({
         port: '8001',
         host: '1.1.1.1'
       });
@@ -221,24 +225,30 @@ describe('bootstrap()', () => {
         .expect(res => res.text.should.eql('<div>one</div>\n'));
     });
 
-    it('stops the service when stop is called', () =>
+    it('stops the service when stop is called', done => {
 
-      bootstrap({
+      const bs = bootstrap({
+        start: false,
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
             '/one': {}
           }
         }]
-      }).stop((server) =>
-        request(server)
-          .get('/one')
-          .end(error => {
-            error.should.be.instanceof(Error);
-            return error.code.should.equal('ECONNRESET');
-          })
-      )
-    );
+      });
+
+      bs.start({
+        port: '8002'
+      }).then(() => {
+        bs.stop().then(() => {
+          require('request')('http://localhost:8002', err => {
+            err.should.be.instanceof(Error);
+            err.code.should.equal('ECONNREFUSED');
+            done();
+          });
+        });
+      });
+    });
 
     it('serves static resources from /public', () => {
       const bs = bootstrap({

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -117,6 +117,57 @@ describe('bootstrap()', () => {
         .expect(res => res.text.should.eql('<div>one</div>\n'));
     });
 
+    it('looks up a view from the route directory', () => {
+      const bs = bootstrap({
+        views: path.resolve(__dirname, '../apps/common/views'),
+        routes: [{
+          views: path.resolve(__dirname, '../apps/app_2/views'),
+          steps: {
+            '/common': {}
+          }
+        }]
+      });
+      return request(bs.server)
+        .get('/common')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(200)
+        .expect(res => res.text.should.eql('<div>from app 2</div>\n'));
+    });
+
+    it('falls back to common views if view not found in route views', () => {
+      const bs = bootstrap({
+        views: path.resolve(__dirname, '../apps/common/views'),
+        routes: [{
+          views: path.resolve(__dirname, '../apps/app_1/views'),
+          steps: {
+            '/common': {}
+          }
+        }]
+      });
+      return request(bs.server)
+        .get('/common')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(200)
+        .expect(res => res.text.should.eql('<div>from common</div>\n'));
+    });
+
+    it('looks up from hof-template-partials if not found in any supplied views dir', () => {
+      const bs = bootstrap({
+        views: path.resolve(__dirname, '../apps/common/views'),
+        routes: [{
+          views: path.resolve(__dirname, '../apps/app_1/views'),
+          steps: {
+            '/step': {}
+          }
+        }]
+      });
+      return request(bs.server)
+        .get('/step')
+        .set('Cookie', ['myCookie=1234'])
+        .expect(200)
+        .expect(res => res.text.should.contain('<div class="content">'));
+    });
+
     it('serves a view on request to an optional baseUrl', () => {
       const bs = bootstrap({
         routes: [{


### PR DESCRIPTION
This PR scopes the instance of express to the export function so global state is not preserved if multiple instances are required. It also replaces the route Router with an instance of express allowing a views dir to be set on the specific route. Express template partials is called per route so partials can also be scoped to journey