### PR TITLE
bugfix - set view engine on subapp

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -55,6 +55,7 @@ module.exports = (config) => {
     path: paths.translations + '/__lng__/__ns__.json'
   });
 
+  app.set('view engine', config.viewEngine);
   app.set('views', [paths.templates].concat(config.sharedViews));
 
   app.use(expressPartialTemplates(app));


### PR DESCRIPTION
expressPartialTemplates requires the view engine to be set in order to add partials

* set view engine to subapp in router.js from config