### PR TITLE
Security updgrades

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const sessionStore = require('./lib/sessions');
 const settings = require('./lib/settings');
 const defaults = require('./lib/defaults');
 const logger = require('./lib/logger');
+const helmet = require('helmet');
 
 const getConfig = function getConfig() {
   const args = [].slice.call(arguments);
@@ -43,6 +44,8 @@ const applyErrorMiddlewares = (app, config, i18n) => {
 module.exports = options => {
 
   const app = express();
+
+  app.use(helmet());
 
   let config = getConfig(options);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -55,6 +55,7 @@ module.exports = (config) => {
     path: paths.translations + '/__lng__/__ns__.json'
   });
 
+  app.set('x-powered-by', false);
   app.set('view engine', config.viewEngine);
   app.set('views', [paths.templates].concat(config.sharedViews));
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "express": "^4.13.4",
     "express-partial-templates": "^0.2.0",
     "express-session": "^1.13.0",
+    "helmet": "^2.3.0",
     "hof": "UKHomeOffice/hof#so-master",
     "hof-template-partials": "^1.0.1",
     "hogan-express-strict": "^0.5.4",


### PR DESCRIPTION
- use helmet to:
  - dnsPrefetchControl controls browser DNS prefetching
  - frameguard to prevent clickjacking
  - hidePoweredBy to remove the X-Powered-By header
  - hsts for HTTP Strict Transport Security
  - ieNoOpen sets X-Download-Options for IE8+
  - noSniff to keep clients from sniffing the MIME type
  - xssFilter adds some small XSS protections
- disable x-powered-by hedaer for every sub-app